### PR TITLE
Add wiki as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "guides"]
+	path = guides
+	url = https://github.com/codepath/ios_guides.wiki.git
+	branch = master


### PR DESCRIPTION
I added the ios_guides GitHub wiki as a submodule similar to how the android_guides are [setup](https://github.com/codepath/android_guides/commit/6149129b30ebcc2e9e97f1813580ff18fdda3a88).
